### PR TITLE
Add gravitational-wave orbital decay

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,7 @@ examples/*/rebound*
 doc/html/*
 doc/latex/*
 !doc/latex/common_envelope_drag.tex
+!doc/latex/gravitational_wave_decay.tex
 doc/Doxyfile
 MANIFEST
 reboundx.egg-info

--- a/doc/effects.rst
+++ b/doc/effects.rst
@@ -480,10 +480,11 @@ Authors                 M. Ali-Dib
 Implementation Paper    `Ritter 1988 <https://ui.adsabs.harvard.edu/abs/1988A%26A...202...93R/abstract>`_
 Based on                `Kolb & Ritter 1990 <https://ui.adsabs.harvard.edu/abs/1990A%26A...236..385K/abstract>`_
 C Example               :ref:`c_example_roche_lobe_mass_transfer`
-Python Example          `roche_lobe_mass_transfer.py <https://github.com/dtamayo/reboundx>`_
+Python Example          `roche_lobe_mass_transfer.py <https://github.com/dtamayo/reboundx>`_, `rlmt_gw_orbital_decay.py <https://github.com/dtamayo/reboundx>`_
 ======================= ================================================================
 
 Transfers mass from a donor to an accretor when the donor overfills its Roche lobe.
+If ``gw_c`` is provided, gravitational wave orbital decay is included using the 2.5PN Peters (1964) prescription.
 If the accretor lies within the donor's radius, a common-envelope drag force is applied.
 
 **Effect Parameters**
@@ -500,6 +501,7 @@ ce_cs (double)               No          Sound speed at donor surface
 ce_alpha_cs (double)         No          Power-law slope of sound speed profile
 ce_xmin (double)             No          Coulomb logarithm parameter
 ce_Qd (double)               No          Geometric drag coefficient
+gw_c (double)                No          Speed of light for gravitational wave decay
 ============================ =========== ============================================
 
 **Particle Parameters**

--- a/doc/latex/gravitational_wave_decay.tex
+++ b/doc/latex/gravitational_wave_decay.tex
@@ -1,0 +1,14 @@
+\section{Gravitational Wave Orbital Decay}
+\label{sec:gw_decay}
+
+Compact binaries lose orbital energy and angular momentum via the emission of gravitational radiation.  In the quadrupole approximation the orbit-averaged evolution of the semi--major axis $a$ and eccentricity $e$ of a binary with component masses $m_1$ and $m_2$ is given by \citet{Peters1964}
+\begin{align}
+  \frac{da}{dt} &= -\frac{64}{5}\frac{G^3 m_1 m_2 (m_1+m_2)}{c^5 a^3 (1-e^2)^{7/2}}\Bigl(1+\frac{73}{24}e^2+\frac{37}{96}e^4\Bigr),\\
+  \frac{de}{dt} &= -\frac{304}{15}e\frac{G^3 m_1 m_2 (m_1+m_2)}{c^5 a^4 (1-e^2)^{5/2}}\Bigl(1+\frac{121}{304}e^2\Bigr).
+\end{align}
+During each operator call we compute the osculating orbit of the donor around the accretor and update $a$ and $e$ using the above expressions over the timestep $\Delta t$.  The donor's position and velocity are then reset using \texttt{reb\_particle\_from\_orbit}.  The parameter ``gw\_c`` specifies the speed of light $c$ in code units.
+
+\bibliographystyle{plainnat}
+\begin{thebibliography}{99}
+\bibitem[Peters(1964)]{Peters1964} Peters, P.~C. 1964, Phys. Rev., 136, 1224
+\end{thebibliography}

--- a/ipython_examples/rlmt_gw_orbital_decay.py
+++ b/ipython_examples/rlmt_gw_orbital_decay.py
@@ -1,0 +1,27 @@
+import rebound
+import reboundx
+import numpy as np
+
+sim = rebound.Simulation()
+sim.units = ('AU','yr','Msun')
+sim.G = 4*np.pi**2
+
+sim.add(m=1.4)  # accretor
+sim.add(m=1.3, a=0.01)  # donor
+sim.particles[1].r = 0.003
+
+rebx = reboundx.Extras(sim)
+rl = rebx.load_operator("roche_lobe_mass_transfer")
+rebx.add_operator(rl)
+
+rl.params['rlmt_donor'] = 1
+rl.params['rlmt_accretor'] = 0
+sim.particles[1].params['rlmt_Hp'] = 1e-5
+sim.particles[1].params['rlmt_mdot0'] = 1e-9
+rl.params['gw_c'] = 63239.7263  # speed of light in AU/yr
+
+for i in range(5):
+    sim.integrate(sim.t+0.1)
+    o = sim.particles[1].orbit(primary=sim.particles[0])
+    print(f"t={sim.t:.2f} a={o.a:.6e} e={o.e:.6e}")
+

--- a/src/core.c
+++ b/src/core.c
@@ -155,6 +155,7 @@ void rebx_register_default_params(struct rebx_extras* rebx){
     rebx_register_param(rebx, "ce_alpha_cs", REBX_TYPE_DOUBLE);
     rebx_register_param(rebx, "ce_xmin", REBX_TYPE_DOUBLE);
     rebx_register_param(rebx, "ce_Qd", REBX_TYPE_DOUBLE);
+    rebx_register_param(rebx, "gw_c", REBX_TYPE_DOUBLE);
 }
 
 void rebx_register_param(struct rebx_extras* const rebx, const char* name, enum rebx_param_type type){

--- a/src/roche_lobe_mass_transfer.c
+++ b/src/roche_lobe_mass_transfer.c
@@ -123,6 +123,7 @@ void rebx_roche_lobe_mass_transfer(struct reb_simulation* const sim, struct rebx
     const double* ce_alpha_cs_ptr = rebx_get_param(rebx, operator->ap, "ce_alpha_cs");
     const double* ce_xmin_ptr = rebx_get_param(rebx, operator->ap, "ce_xmin");
     const double* ce_Qd_ptr = rebx_get_param(rebx, operator->ap, "ce_Qd");
+    const double* gw_c_ptr = rebx_get_param(rebx, operator->ap, "gw_c");
 
     if (Hp_ptr == NULL || mdot0_ptr == NULL){
         rebx_error(rebx, "Need to set rlmt_Hp and rlmt_mdot0 on donor particle.\n");
@@ -196,6 +197,32 @@ void rebx_roche_lobe_mass_transfer(struct reb_simulation* const sim, struct rebx
             accretor->vx -= fc*vrelx*dt;
             accretor->vy -= fc*vrely*dt;
             accretor->vz -= fc*vrelz*dt;
+        }
+    }
+
+    if (gw_c_ptr != NULL && *gw_c_ptr > 0.){
+        struct reb_orbit o = reb_orbit_from_particle(sim->G, *donor, *accretor);
+        if (o.a > 0.){
+            const double c = *gw_c_ptr;
+            const double m1 = donor->m;
+            const double m2 = accretor->m;
+            const double G3 = sim->G*sim->G*sim->G;
+            const double e = o.e;
+            const double a = o.a;
+            const double fac_a = -64./5. * G3*m1*m2*(m1+m2)/(pow(c,5)*pow(a,3)*pow(1.-e*e,3.5))*(1.+73./24.*e*e+37./96.*e*e*e*e);
+            const double fac_e = -304./15. * e * G3*m1*m2*(m1+m2)/(pow(c,5)*pow(a,4)*pow(1.-e*e,2.5))*(1.+121./304.*e*e);
+            double new_a = a + fac_a*dt;
+            double new_e = e + fac_e*dt;
+            if (new_a < 0.) new_a = 0.;
+            if (new_e < 0.) new_e = 0.;
+            if (new_e > 0.999999) new_e = 0.999999;
+            struct reb_particle np = reb_particle_from_orbit(sim->G, *accretor, m1, new_a, new_e, o.inc, o.Omega, o.omega, o.f);
+            donor->x = np.x;
+            donor->y = np.y;
+            donor->z = np.z;
+            donor->vx = np.vx;
+            donor->vy = np.vy;
+            donor->vz = np.vz;
         }
     }
 


### PR DESCRIPTION
## Summary
- extend Roche-Lobe Mass Transfer operator with optional 2.5PN gravitational-wave orbital decay
- register `gw_c` parameter and document its usage
- provide a Python example demonstrating Roche-lobe mass transfer with gravitational-wave decay
- add LaTeX documentation of the gravitational-wave implementation

## Testing
- `pip install -e .`
- `python ipython_examples/rlmt_gw_orbital_decay.py`

------
https://chatgpt.com/codex/tasks/task_e_686e4447abc4833284dc432017e44c06