### PR TITLE
Drop solar-mass scaling param from SSE effect

### DIFF
--- a/doc/effects.rst
+++ b/doc/effects.rst
@@ -579,10 +579,16 @@ single-star evolution relations.  Tracks a particle's age via the
 ============================ =========== ======================================
 Field (C type)               Required    Description
 ============================ =========== ======================================
-sse_Msun (double)            No          Solar mass in code units
 sse_Rsun (double)            No          Solar radius in code units
 sse_Lsun (double)            No          Solar luminosity in code units
+sse_R_coeff (double)        No          Multiplicative factor for R(M) scaling
+sse_R_exp (double)          No          Mass exponent for R(M) scaling
+sse_L_coeff (double)        No          Multiplicative factor for L(M) scaling
+sse_L_exp (double)          No          Mass exponent for L(M) scaling
 ============================ =========== ======================================
+
+The star's mass is read directly from its ``m`` value in the simulation and
+should be expressed in solar masses.
 
 **Particle Parameters**
 

--- a/ipython_examples/stellar_evolution_sse.py
+++ b/ipython_examples/stellar_evolution_sse.py
@@ -12,6 +12,24 @@ rebx.add_operator(sse)
 
 sim.particles[0].params['sse_age'] = 0.0
 
+print("Default main-sequence evolution:")
+for i in range(5):
+    sim.integrate(sim.t+1e3)
+    R = sim.particles[0].r
+    L = sim.particles[0].params['swml_L']
+    print(f"t={sim.t:.0f} yr, R={R:.4f} Rsun, L={L:.4f} Lsun")
+
+# Customize parameters
+
+sse.params['sse_R_coeff'] = 0.9
+sse.params['sse_R_exp'] = 0.6
+sse.params['sse_L_coeff'] = 1.2
+sse.params['sse_L_exp'] = 4.0
+
+sim.t = 0.0
+sim.particles[0].params['sse_age'] = 0.0
+
+print("\nCustom parameters:")
 for i in range(5):
     sim.integrate(sim.t+1e3)
     R = sim.particles[0].r

--- a/src/core.c
+++ b/src/core.c
@@ -165,9 +165,12 @@ void rebx_register_default_params(struct rebx_extras* rebx){
     rebx_register_param(rebx, "swml_Rsun", REBX_TYPE_DOUBLE);
     rebx_register_param(rebx, "swml_Lsun", REBX_TYPE_DOUBLE);
     rebx_register_param(rebx, "sse_age", REBX_TYPE_DOUBLE);
-    rebx_register_param(rebx, "sse_Msun", REBX_TYPE_DOUBLE);
     rebx_register_param(rebx, "sse_Rsun", REBX_TYPE_DOUBLE);
     rebx_register_param(rebx, "sse_Lsun", REBX_TYPE_DOUBLE);
+    rebx_register_param(rebx, "sse_R_coeff", REBX_TYPE_DOUBLE);
+    rebx_register_param(rebx, "sse_R_exp", REBX_TYPE_DOUBLE);
+    rebx_register_param(rebx, "sse_L_coeff", REBX_TYPE_DOUBLE);
+    rebx_register_param(rebx, "sse_L_exp", REBX_TYPE_DOUBLE);
 }
 
 void rebx_register_param(struct rebx_extras* const rebx, const char* name, enum rebx_param_type type){


### PR DESCRIPTION
## Summary
- remove `sse_Msun` references
- assume particle masses are already in solar units
- clarify documentation about mass units

## Testing
- `pip install -e . -v`
- `pip install -r requirements.txt`
- `python -m unittest discover -s reboundx/test/ -v`


------
https://chatgpt.com/codex/tasks/task_e_686f7946aa0c8332bef2f4a0411ee6f2