### PR TITLE
Drop sse_age and demo winds with SSE

### DIFF
--- a/doc/effects.rst
+++ b/doc/effects.rst
@@ -570,27 +570,26 @@ C Example               :ref:`c_example_stellar_evolution_sse`
 Python Example          `stellar_evolution_sse.py <https://github.com/dtamayo/reboundx>`_
 ======================= ===============================================
 
-Updates stellar radius and luminosity according to simplified analytic
-single-star evolution relations.  Tracks a particle's age via the
-``sse_age`` parameter and updates ``swml_R`` and ``swml_L`` accordingly.
+Updates stellar radius and luminosity using simplified analytic
+mass--radius and mass--luminosity relations.  The operator stores the
+resulting values in ``swml_R`` and ``swml_L`` so other effects (e.g.,
+stellar winds) can access them.
 
 **Effect Parameters**
 
 ============================ =========== ======================================
 Field (C type)               Required    Description
 ============================ =========== ======================================
-sse_Msun (double)            No          Solar mass in code units
 sse_Rsun (double)            No          Solar radius in code units
 sse_Lsun (double)            No          Solar luminosity in code units
+sse_R_coeff (double)        No          Multiplicative factor for R(M) scaling
+sse_R_exp (double)          No          Mass exponent for R(M) scaling
+sse_L_coeff (double)        No          Multiplicative factor for L(M) scaling
+sse_L_exp (double)          No          Mass exponent for L(M) scaling
 ============================ =========== ======================================
 
-**Particle Parameters**
-
-============================ =========== ======================================
-Field (C type)               Required    Description
-============================ =========== ======================================
-sse_age (double)             Yes         Stellar age
-============================ =========== ======================================
+The star's mass is read directly from its ``m`` value in the simulation and
+should be expressed in solar masses.
 
 
 Tides

--- a/examples/stellar_evolution_sse/problem.c
+++ b/examples/stellar_evolution_sse/problem.c
@@ -2,7 +2,7 @@
  * Stellar Evolution SSE Example
  *
  * Demonstrates the simplified stellar_evolution_sse operator that updates
- * a star's radius and luminosity with age.
+ * a star's radius and luminosity based on its mass.
  */
 #include <stdio.h>
 #include <stdlib.h>
@@ -28,7 +28,6 @@ int main(int argc, char* argv[]){
     struct rebx_operator* sse = rebx_load_operator(rebx, "stellar_evolution_sse");
     rebx_add_operator(rebx, sse);
 
-    rebx_set_param_double(rebx, &sim->particles[0].ap, "sse_age", 0.0);
 
     for(int i=0;i<10;i++){
         reb_simulation_integrate(sim, (i+1)*tmax/10.);

--- a/ipython_examples/stellar_evolution_sse.py
+++ b/ipython_examples/stellar_evolution_sse.py
@@ -10,8 +10,23 @@ rebx = reboundx.Extras(sim)
 sse = rebx.load_operator("stellar_evolution_sse")
 rebx.add_operator(sse)
 
-sim.particles[0].params['sse_age'] = 0.0
+print("Default main-sequence scaling:")
+for i in range(5):
+    sim.integrate(sim.t+1e3)
+    R = sim.particles[0].r
+    L = sim.particles[0].params['swml_L']
+    print(f"t={sim.t:.0f} yr, R={R:.4f} Rsun, L={L:.4f} Lsun")
 
+# Customize parameters
+
+sse.params['sse_R_coeff'] = 0.9
+sse.params['sse_R_exp'] = 0.6
+sse.params['sse_L_coeff'] = 1.2
+sse.params['sse_L_exp'] = 4.0
+
+sim.t = 0.0
+
+print("\nCustom parameters:")
 for i in range(5):
     sim.integrate(sim.t+1e3)
     R = sim.particles[0].r

--- a/ipython_examples/stellar_wind_with_sse.py
+++ b/ipython_examples/stellar_wind_with_sse.py
@@ -1,0 +1,27 @@
+import rebound
+import reboundx
+
+sim = rebound.Simulation()
+sim.units = ('AU','yr','Msun')
+sim.G = 4*3.141592653589793**2
+sim.add(m=1., r=1.)
+
+rebx = reboundx.Extras(sim)
+wind = rebx.load_operator('stellar_wind_mass_loss')
+rebx.add_operator(wind)
+
+sse = rebx.load_operator('stellar_evolution_sse')
+rebx.add_operator(sse)
+
+# wind parameters
+sim.particles[0].params['swml_eta'] = 0.5
+sim.particles[0].params['swml_R'] = 1.0
+sim.particles[0].params['swml_L'] = 1.0
+
+print("Mass, radius and luminosity with winds:")
+for i in range(5):
+    sim.integrate(sim.t + 2e4)
+    M = sim.particles[0].m
+    R = sim.particles[0].r
+    L = sim.particles[0].params['swml_L']
+    print(f"t={sim.t:.0f} yr, M={M:.6f} Msun, R={R:.3f} Rsun, L={L:.3f} Lsun")

--- a/src/core.c
+++ b/src/core.c
@@ -164,10 +164,12 @@ void rebx_register_default_params(struct rebx_extras* rebx){
     rebx_register_param(rebx, "swml_Msun", REBX_TYPE_DOUBLE);
     rebx_register_param(rebx, "swml_Rsun", REBX_TYPE_DOUBLE);
     rebx_register_param(rebx, "swml_Lsun", REBX_TYPE_DOUBLE);
-    rebx_register_param(rebx, "sse_age", REBX_TYPE_DOUBLE);
-    rebx_register_param(rebx, "sse_Msun", REBX_TYPE_DOUBLE);
     rebx_register_param(rebx, "sse_Rsun", REBX_TYPE_DOUBLE);
     rebx_register_param(rebx, "sse_Lsun", REBX_TYPE_DOUBLE);
+    rebx_register_param(rebx, "sse_R_coeff", REBX_TYPE_DOUBLE);
+    rebx_register_param(rebx, "sse_R_exp", REBX_TYPE_DOUBLE);
+    rebx_register_param(rebx, "sse_L_coeff", REBX_TYPE_DOUBLE);
+    rebx_register_param(rebx, "sse_L_exp", REBX_TYPE_DOUBLE);
 }
 
 void rebx_register_param(struct rebx_extras* const rebx, const char* name, enum rebx_param_type type){

--- a/src/stellar_evolution_sse.c
+++ b/src/stellar_evolution_sse.c
@@ -2,47 +2,30 @@
  * @file    stellar_evolution_sse.c
  * @brief   Very simplified stellar evolution update using analytic scalings.
  *
- * This operator updates a star's radius and luminosity based on its age
- * following approximate single-star evolution relations inspired by the
- * SSE formulation of \citet{Hurley2000}.  It is not a full
- * implementation of SSE, but provides time-dependent stellar properties
- * for testing wind mass loss.
+ * This operator updates a star's radius and luminosity using simple
+ * power-law scalings with its mass, inspired by the SSE formulation of
+ * \citet{Hurley2000}.  It is not a full implementation of SSE, but
+ * provides mass-dependent stellar properties for testing wind mass loss.
  *
- * The main-sequence lifetime is approximated by
- *
- * .. math::
- *    t_{\rm MS} \approx 10^{10}\,\mathrm{yr}\,(M/M_\odot)^{-2.5}
- *
- * The zero-age main sequence radius and luminosity scale as
+ * The zero-age main sequence radius and luminosity scale approximately as
  *
  * .. math::
- *    R_{\rm ZAMS} \propto (M/M_\odot)^{0.8},\qquad
- *    L_{\rm ZAMS} \propto (M/M_\odot)^{3.5}.
- *
- * As the star ages on the main sequence, both its radius and luminosity
- * increase linearly with the fractional age $\tau=t/t_{\rm MS}$ until
- * $\tau=1$, after which they are held fixed.  The updated radius and
- * luminosity are stored both in the particle's ``r`` field and in the
- * parameters ``swml_R`` and ``swml_L`` so that the wind mass-loss
- * operator can access them.
- *
- * **Particle Parameters**
+ *    R \propto (M/M_\odot)^{0.8},\qquad
+ *    L \propto (M/M_\odot)^{3.5}.
  *
  * ============================ =========== ====================================
  * Field (C type)               Required    Description
  * ============================ =========== ====================================
- * sse_age (double)             Yes         Current stellar age
- * ============================ =========== ====================================
- *
- * **Operator Parameters**
- *
- * ============================ =========== ====================================
- * Field (C type)               Required    Description
- * ============================ =========== ====================================
- * sse_Msun (double)            No          Solar mass in code units (default 1)
  * sse_Rsun (double)            No          Solar radius in code units (default 1)
  * sse_Lsun (double)            No          Solar luminosity in code units (default 1)
+ * sse_R_coeff (double)        No          Multiplicative factor for radius scaling (default 1)
+ * sse_R_exp (double)          No          Mass exponent for radius scaling (default 0.8)
+ * sse_L_coeff (double)        No          Multiplicative factor for luminosity scaling (default 1)
+ * sse_L_exp (double)          No          Mass exponent for luminosity scaling (default 3.5)
  * ============================ =========== ====================================
+ *
+ * The stellar mass is read directly from the particle's ``m`` field and is
+ * assumed to be expressed in solar masses.
  */
 
 #include <stdio.h>
@@ -55,31 +38,33 @@ void rebx_stellar_evolution_sse(struct reb_simulation* const sim, struct rebx_op
     struct rebx_extras* const rebx = sim->extras;
     const int N_real = sim->N - sim->N_var;
 
-    double Msun = 1.;
     double Rsun = 1.;
     double Lsun = 1.;
-    const double* Msun_ptr = rebx_get_param(rebx, operator->ap, "sse_Msun");
+    double R_coeff = 1.;
+    double R_exp = 0.8;
+    double L_coeff = 1.;
+    double L_exp = 3.5;
+
     const double* Rsun_ptr = rebx_get_param(rebx, operator->ap, "sse_Rsun");
     const double* Lsun_ptr = rebx_get_param(rebx, operator->ap, "sse_Lsun");
-    if (Msun_ptr) Msun = *Msun_ptr;
+    const double* R_coeff_ptr  = rebx_get_param(rebx, operator->ap, "sse_R_coeff");
+    const double* R_exp_ptr    = rebx_get_param(rebx, operator->ap, "sse_R_exp");
+    const double* L_coeff_ptr  = rebx_get_param(rebx, operator->ap, "sse_L_coeff");
+    const double* L_exp_ptr    = rebx_get_param(rebx, operator->ap, "sse_L_exp");
     if (Rsun_ptr) Rsun = *Rsun_ptr;
     if (Lsun_ptr) Lsun = *Lsun_ptr;
+    if (R_coeff_ptr) R_coeff = *R_coeff_ptr;
+    if (R_exp_ptr)   R_exp   = *R_exp_ptr;
+    if (L_coeff_ptr) L_coeff = *L_coeff_ptr;
+    if (L_exp_ptr)   L_exp   = *L_exp_ptr;
 
     for (int i=0; i<N_real; i++){
         struct reb_particle* const p = &sim->particles[i];
-        double* age_ptr = rebx_get_param(rebx, p->ap, "sse_age");
-        if (age_ptr == NULL){
-            continue;
-        }
-        *age_ptr += dt;
-        const double mass_ratio = p->m / Msun;
-        const double tms = 1e10 * pow(mass_ratio, -2.5); // yrs in code units
-        double tau = *age_ptr / tms;
-        if (tau > 1.) tau = 1.;
-        const double Rzams = Rsun * pow(mass_ratio, 0.8);
-        const double Lzams = Lsun * pow(mass_ratio, 3.5);
-        const double R = Rzams * (1. + 5.*tau);
-        const double L = Lzams * (1. + 10.*tau);
+
+        const double mass_ratio = p->m; // assume simulation masses are in M_sun
+        double R = R_coeff * Rsun * pow(mass_ratio, R_exp);
+        double L = L_coeff * Lsun * pow(mass_ratio, L_exp);
+
         p->r = R;
         rebx_set_param_double(rebx, &p->ap, "swml_R", R);
         rebx_set_param_double(rebx, &p->ap, "swml_L", L);


### PR DESCRIPTION
## Summary
- remove stale `sse_age` parameter from SSE effect and documentation
- simplify SSE operator to update radius and luminosity from mass only
- update Python and C examples
- add new example showing radius and luminosity change while stellar winds remove mass

## Testing
- `pip install -e . -v`
- `pip install -r requirements.txt`
- `python -m unittest discover -s reboundx/test/ -v`


------
https://chatgpt.com/codex/tasks/task_e_686f7946aa0c8332bef2f4a0411ee6f2