### PR TITLE
docs: sync binary module descriptions

### DIFF
--- a/doc_binary.tex
+++ b/doc_binary.tex
@@ -240,8 +240,9 @@ replaced with $\omega\,\omega_{\rm sat}^2$, yielding a constant torque at high
 rotation rates.
 
 \paragraph{Activation.} Magnetic braking is applied only when a particle sets
-\texttt{mb\_on}=1 and has \texttt{mb\_convective}=1.  Missing parameters,
-non‑positive $I$, or vanishing spin vectors automatically disable the update.
+\texttt{mb\_on}=1 and has \texttt{mb\_convective}=1. Missing parameters,
+non‑positive $I$, vanishing spin vectors, or non‑finite $M$ or $R$ all
+bypass the update.
 
 \begin{table}[h]
 \centering\footnotesize
@@ -272,8 +273,11 @@ $R$, the mass-loss rate is
 \;M_\odot\,\mathrm{yr}^{-1},
 \]
 where the dimensionless efficiency $\eta$ together with $L$ and $R$ are
-specified per particle. The prefactor and solar reference values can be
-adjusted via operator parameters (Table~\ref{tab:swml}).
+specified per particle. Mass is removed isotropically with no linear-momentum
+recoil; virtual particles are ignored and after mass loss the system is
+recentred on the centre of mass. The prefactor, solar reference values, and
+the year length can be adjusted via operator parameters
+(Table~\ref{tab:swml}).
 
 \begin{table}[h]
 \centering\footnotesize
@@ -290,6 +294,7 @@ Name (scope) & Unit & Default & Purpose \\
 \texttt{swml\_Msun}  (op) & mass & 1 & Solar mass in code units\\
 \texttt{swml\_Rsun}  (op) & length & 1 & Solar radius in code units\\
 \texttt{swml\_Lsun}  (op) & luminosity & 1 & Solar luminosity in code units\\
+\texttt{swml\_year}  (op) & time & 1 & Length of Julian year in code units\\
 \bottomrule
 \end{tabular}
 \end{table}
@@ -371,8 +376,9 @@ dissipative $2.5$PN terms for every particle pair.
 For bodies with masses $m_i$ and $m_j$ separated by $\mathbf{r}$ and with
 relative velocity $\mathbf{v}$, the force adds to the relative acceleration
 \begin{align}
-\mathbf{a}_{1\mathrm{PN}} &= -\frac{G m}{r^2 c^2}\Bigl[\mathbf{n}\bigl((1+3\eta)v^2 - 2(2+\eta)\frac{G m}{r}-\tfrac{3}{2}\eta\dot r^2\bigr)
- +(4-2\eta)\dot r\,\mathbf{v}\Bigr],\\
+\mathbf{a}_{1\mathrm{PN}} &= -\frac{G m}{r^2 c^2}
+   \Bigl[\mathbf{n}\bigl((1+3\eta)v^2 - 2(2+\eta)\frac{G m}{r}-\tfrac{3}{2}\eta\dot r^2\bigr)\Bigr]
+   +\frac{G m}{r^2 c^2}(4-2\eta)\dot r\,\mathbf{v},\\
 \mathbf{a}_{2.5\mathrm{PN}} &= \frac{8 G^2 m^2 \eta}{5 c^5 r^3}\Bigl[\dot r\Bigl(18 v^2 + \tfrac{2}{3}\frac{G m}{r}-25\dot r^2\Bigr)\mathbf{n}-\Bigl(6 v^2 - 2\frac{G m}{r}-15\dot r^2\Bigr)\mathbf{v}\Bigr],
 \end{align}
 where $m=m_i+m_j$, $\eta=m_i m_j/m^2$, $\mathbf{n}=\mathbf{r}/r$, and


### PR DESCRIPTION
## Summary
- clarify magnetic-braking activation criteria and invalid mass/radius handling
- expand stellar-wind section with isotropic loss, COM recentering, and `swml_year`
- correct 1PN post-Newtonian acceleration sign

## Testing
- `pdflatex -interaction=nonstopmode doc_binary.tex`
- `pytest` *(fails: cannot open shared object file libreboundx.cpython-312-x86_64-linux-gnu.so)*
- `make` *(fails: REBOUNDx not in the same directory as REBOUND)*

------
https://chatgpt.com/codex/tasks/task_e_6890c55f24b4833286ea43a8d6ec95ae