### PR TITLE
docs: expand thermally driven wind description

### DIFF
--- a/doc_binary.tex
+++ b/doc_binary.tex
@@ -311,16 +311,22 @@ Name (scope) & Unit & Default & Purpose \\
 \label{sec:tdw}
 
 Thermal pressure can launch isotropic winds that carry away mass. For a star
-of mass $M$, surface temperature $T$, and radius $R$, we adopt
+of mass $M$, coronal temperature $T$, and radius $R$, we adopt a Parker-like
+scaling
 \[
-\dot M = -C_{\rm th}\,\eta\,\left(\frac{R}{R_\odot}\right)^2\left(\frac{T}{T_\odot}\right)^2\frac{M_\odot}{M}
+\dot M = -C_{\rm th}\,\eta\,\left(\frac{R}{R_\odot}\right)^{\alpha_R}
+                   \left(\frac{T}{T_\odot}\right)^{\alpha_T}
+                   \left(\frac{M_\odot}{M}\right)^{\alpha_M}
 \;M_\odot\,\mathrm{yr}^{-1},
 \]
-where the dimensionless efficiency $\eta$ along with $T$ and $R$ are provided
-per particle.  Mass is removed isotropically with no linear-momentum recoil,
-virtual particles are ignored, and after mass loss the system is recentred on
-the centre of mass.  The prefactor, solar reference values, and the year length
-can be adjusted via operator parameters (Table~\ref{tab:tdw}).
+where $\eta$ is a dimensionless heating efficiency and the exponents have
+defaults $(\alpha_R,\alpha_T,\alpha_M)=(2,\tfrac{3}{2},1)$.  Mass is removed
+isotropically with no linear-momentum recoil; virtual particles are ignored,
+and after mass loss the system is recentred on the centre of mass.  The
+prefactor, solar reference values, exponents, maximum fractional mass change
+per call, and the year length can be adjusted via operator parameters
+(Table~\ref{tab:tdw}). The operator is unit-agnostic if these scaling
+constants are specified consistently.
 
 \begin{table}[h]
 \centering\footnotesize
@@ -331,13 +337,17 @@ can be adjusted via operator parameters (Table~\ref{tab:tdw}).
 Name (scope) & Unit & Default & Purpose \\
 \midrule
 \texttt{tdw\_eta} (part) & — & — & Wind efficiency $\eta$\\
-\texttt{tdw\_T}   (part) & temperature & — & Surface temperature $T$\\
+\texttt{tdw\_T}   (part) & temperature & — & Coronal temperature $T$\\
 \texttt{tdw\_R}   (part) & length & — & Stellar radius $R$\\[0.2em]
-\texttt{tdw\_const} (op) & $M_\odot$/yr & $1\times10^{-14}$ & Thermal-wind prefactor\\
+\texttt{tdw\_const} (op) & $M_\odot$/yr & $2\times10^{-14}$ & Thermal-wind prefactor $C_{\rm th}$\\
 \texttt{tdw\_Msun}  (op) & mass & 1 & Solar mass in code units\\
 \texttt{tdw\_Rsun}  (op) & length & 1 & Solar radius in code units\\
-\texttt{tdw\_Tsun}  (op) & temperature & 1 & Solar temperature in code units\\
+\texttt{tdw\_Tsun}  (op) & temperature & $1.5\times10^6$ & Reference corona $T_\odot$ in code units\\
 \texttt{tdw\_year}  (op) & time & 1 & Length of Julian year in code units\\
+\texttt{tdw\_alpha\_R} (op) & — & 2 & Exponent $\alpha_R$ on $R/R_\odot$\\
+\texttt{tdw\_alpha\_T} (op) & — & $3/2$ & Exponent $\alpha_T$ on $T/T_\odot$\\
+\texttt{tdw\_alpha\_M} (op) & — & 1 & Exponent $\alpha_M$ on $M_\odot/M$\\
+\texttt{tdw\_max\_dlnM} (op) & — & 0.1 & Max $|\Delta M|/M$ per call\\
 \bottomrule
 \end{tabular}
 \end{table}


### PR DESCRIPTION
## Summary
- document Parker-like scaling for thermally driven stellar winds with adjustable exponents
- enumerate all thermally driven wind parameters and update defaults

## Testing
- `make` *(fails: REBOUNDx not in same directory as REBOUND)*
- `python -m pytest` *(fails: cannot load compiled libreboundx shared object)*

------
https://chatgpt.com/codex/tasks/task_e_6890eef775948332be4ce68351d2b934