### PR TITLE
Add test for stellar wind and thermally driven winds

### DIFF
--- a/tests_rebound-S/test_stellar_winds.py
+++ b/tests_rebound-S/test_stellar_winds.py
@@ -1,0 +1,35 @@
+import math
+import unittest
+import rebound
+import reboundx
+
+class TestStellarWinds(unittest.TestCase):
+    def test_mass_loss_with_sse(self):
+        sim = rebound.Simulation()
+        sim.units = ('AU', 'yr', 'Msun')
+        sim.G = 4 * math.pi**2
+        sim.add(m=1.0, r=1.0)
+
+        rebx = reboundx.Extras(sim)
+        swml = rebx.load_operator('stellar_wind_mass_loss')
+        rebx.add_operator(swml)
+        tdw = rebx.load_operator('thermally_driven_winds')
+        rebx.add_operator(tdw)
+        sse = rebx.load_operator('stellar_evolution_sse')
+        rebx.add_operator(sse)
+
+        star = sim.particles[0]
+        star.params['swml_eta'] = 0.5
+        star.params['tdw_eta'] = 1.0
+        star.params['tdw_T'] = 1.5e6
+        star.params['tdw_R'] = star.r
+
+        initial_mass = star.m
+        for _ in range(5):
+            sim.integrate(sim.t + 2.0e4)
+            star.params['tdw_R'] = star.r
+
+        self.assertLess(star.m, initial_mass)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- add regression test combining stellar wind mass loss and thermally driven winds with simplified stellar evolution

## Testing
- `pytest tests_rebound-S/test_stellar_winds.py -q` *(fails: No module named 'reboundx')*
- `pip install -e .` *(fails: error in post_newtonian.c: unknown type name 'reb_vec3d')*

------
https://chatgpt.com/codex/tasks/task_e_68944860651c8332b798c42f813392de