### PR TITLE
Make SSE scaling particle-level

### DIFF
--- a/doc_binary.tex
+++ b/doc_binary.tex
@@ -390,8 +390,11 @@ L = L_{\rm coeff} L_\odot \left(\frac{M}{M_\odot}\right)^{L_{\rm exp}}.
 The mass ratio $M/M_\odot$ uses the operator parameter
 \texttt{sse\_Msun} (default 1) to convert code masses into solar masses;
 \texttt{sse\_Rsun} and \texttt{sse\_Lsun} analogously define the solar radius
-and luminosity in code units.  The particle's radius field is replaced by $R$,
-and the values $R$ and $L$ are written to the attributes
+and luminosity in code units.  Each particle may override the scaling using the
+particle-level parameters \texttt{sse\_R\_coeff}, \texttt{sse\_R\_exp},
+\texttt{sse\_L\_coeff}, and \texttt{sse\_L\_exp}; if unspecified, the default
+values in Table~\ref{tab:sse} are applied.  The particle's radius field is
+replaced by $R$, and the values $R$ and $L$ are written to the attributes
 \texttt{swml\_R} and \texttt{swml\_L} so that the wind-mass-loss operator can
 consume them. Virtual particles are skipped, and stellar masses remain
 unchanged.
@@ -407,10 +410,10 @@ Name (scope) & Unit & Default & Purpose \\
 \texttt{sse\_Msun}   (op) & mass      & 1   & Solar mass in code units\\
 \texttt{sse\_Rsun}   (op) & length     & 1   & Solar radius in code units\\
 \texttt{sse\_Lsun}   (op) & luminosity & 1   & Solar luminosity in code units\\
-\texttt{sse\_R\_coeff} (op) & —       & 1   & Radius scaling prefactor\\
-\texttt{sse\_R\_exp}   (op) & —       & 0.8 & Radius mass exponent\\
-\texttt{sse\_L\_coeff} (op) & —       & 1   & Luminosity scaling prefactor\\
-\texttt{sse\_L\_exp}   (op) & —       & 3.5 & Luminosity mass exponent\\
+\texttt{sse\_R\_coeff} (part) & —       & 1   & Radius scaling prefactor\\
+\texttt{sse\_R\_exp}   (part) & —       & 0.8 & Radius mass exponent\\
+\texttt{sse\_L\_coeff} (part) & —       & 1   & Luminosity scaling prefactor\\
+\texttt{sse\_L\_exp}   (part) & —       & 3.5 & Luminosity mass exponent\\
 \bottomrule
 \end{tabular}
 \end{table}

--- a/ipython_examples/stellar_evolution_sse.py
+++ b/ipython_examples/stellar_evolution_sse.py
@@ -19,10 +19,10 @@ for i in range(5):
 
 # Customize parameters
 
-sse.params['sse_R_coeff'] = 0.9
-sse.params['sse_R_exp'] = 0.6
-sse.params['sse_L_coeff'] = 1.2
-sse.params['sse_L_exp'] = 4.0
+sim.particles[0].params['sse_R_coeff'] = 0.9
+sim.particles[0].params['sse_R_exp'] = 0.6
+sim.particles[0].params['sse_L_coeff'] = 1.2
+sim.particles[0].params['sse_L_exp'] = 4.0
 
 sim.t = 0.0
 
@@ -36,10 +36,10 @@ for i in range(5):
 
 # Customize parameters
 
-sse.params['sse_R_coeff'] = 0.9
-sse.params['sse_R_exp'] = 0.6
-sse.params['sse_L_coeff'] = 1.2
-sse.params['sse_L_exp'] = 4.0
+sim.particles[0].params['sse_R_coeff'] = 0.9
+sim.particles[0].params['sse_R_exp'] = 0.6
+sim.particles[0].params['sse_L_coeff'] = 1.2
+sim.particles[0].params['sse_L_exp'] = 4.0
 
 sim.t = 0.0
 sim.particles[0].params['sse_age'] = 0.0

--- a/src/core.c
+++ b/src/core.c
@@ -193,9 +193,12 @@ void rebx_register_default_params(struct rebx_extras* rebx){
     rebx_register_param(rebx, "tdw_alpha_T", REBX_TYPE_DOUBLE);
     rebx_register_param(rebx, "tdw_alpha_M", REBX_TYPE_DOUBLE);
     rebx_register_param(rebx, "tdw_max_dlnM", REBX_TYPE_DOUBLE);
+    // Simplified stellar evolution operator
+    // Global constants
     rebx_register_param(rebx, "sse_Msun", REBX_TYPE_DOUBLE);
     rebx_register_param(rebx, "sse_Rsun", REBX_TYPE_DOUBLE);
     rebx_register_param(rebx, "sse_Lsun", REBX_TYPE_DOUBLE);
+    // Particle-level scaling parameters
     rebx_register_param(rebx, "sse_R_coeff", REBX_TYPE_DOUBLE);
     rebx_register_param(rebx, "sse_R_exp", REBX_TYPE_DOUBLE);
     rebx_register_param(rebx, "sse_L_coeff", REBX_TYPE_DOUBLE);

--- a/src/core.h
+++ b/src/core.h
@@ -87,6 +87,7 @@ void rebx_lense_thirring(struct reb_simulation* const sim, struct rebx_force* co
 void rebx_modify_mass(struct reb_simulation* const sim, struct rebx_operator* const operator, const double dt);
 void rebx_stellar_wind_mass_loss(struct reb_simulation* const sim, struct rebx_operator* const operator, const double dt);
 void rebx_thermally_driven_winds(struct reb_simulation* const sim, struct rebx_operator* const operator, const double dt);
+// Simplified stellar evolution; scaling parameters live on particles
 void rebx_stellar_evolution_sse(struct reb_simulation* const sim, struct rebx_operator* const operator, const double dt);
 void rebx_roche_lobe_mass_transfer(struct reb_simulation* const sim, struct rebx_operator* const operator, const double dt);
 void rebx_integrate_force(struct reb_simulation* const sim, struct rebx_operator* const operator, const double dt);

--- a/src/stellar_evolution_sse.c
+++ b/src/stellar_evolution_sse.c
@@ -43,28 +43,33 @@ void rebx_stellar_evolution_sse(struct reb_simulation* const sim, struct rebx_op
     double Msun = 1.;
     double Rsun = 1.;
     double Lsun = 1.;
-    double R_coeff = 1.;
-    double R_exp = 0.8;
-    double L_coeff = 1.;
-    double L_exp = 3.5;
+    // Default scaling coefficients/exponents
+    const double R_coeff_default = 1.;
+    const double R_exp_default   = 0.8;
+    const double L_coeff_default = 1.;
+    const double L_exp_default   = 3.5;
 
     const double* Msun_ptr = rebx_get_param(rebx, operator->ap, "sse_Msun");
     const double* Rsun_ptr = rebx_get_param(rebx, operator->ap, "sse_Rsun");
     const double* Lsun_ptr = rebx_get_param(rebx, operator->ap, "sse_Lsun");
-    const double* R_coeff_ptr  = rebx_get_param(rebx, operator->ap, "sse_R_coeff");
-    const double* R_exp_ptr    = rebx_get_param(rebx, operator->ap, "sse_R_exp");
-    const double* L_coeff_ptr  = rebx_get_param(rebx, operator->ap, "sse_L_coeff");
-    const double* L_exp_ptr    = rebx_get_param(rebx, operator->ap, "sse_L_exp");
     if (Msun_ptr) Msun = *Msun_ptr;
     if (Rsun_ptr) Rsun = *Rsun_ptr;
     if (Lsun_ptr) Lsun = *Lsun_ptr;
-    if (R_coeff_ptr) R_coeff = *R_coeff_ptr;
-    if (R_exp_ptr)   R_exp   = *R_exp_ptr;
-    if (L_coeff_ptr) L_coeff = *L_coeff_ptr;
-    if (L_exp_ptr)   L_exp   = *L_exp_ptr;
 
     for (int i=0; i<N_real; i++){
         struct reb_particle* const p = &sim->particles[i];
+        double R_coeff = R_coeff_default;
+        double R_exp   = R_exp_default;
+        double L_coeff = L_coeff_default;
+        double L_exp   = L_exp_default;
+        const double* R_coeff_ptr = rebx_get_param(rebx, p->ap, "sse_R_coeff");
+        const double* R_exp_ptr   = rebx_get_param(rebx, p->ap, "sse_R_exp");
+        const double* L_coeff_ptr = rebx_get_param(rebx, p->ap, "sse_L_coeff");
+        const double* L_exp_ptr   = rebx_get_param(rebx, p->ap, "sse_L_exp");
+        if (R_coeff_ptr) R_coeff = *R_coeff_ptr;
+        if (R_exp_ptr)   R_exp   = *R_exp_ptr;
+        if (L_coeff_ptr) L_coeff = *L_coeff_ptr;
+        if (L_exp_ptr)   L_exp   = *L_exp_ptr;
         const double mass_ratio = p->m / Msun;
         double R = R_coeff * Rsun * pow(mass_ratio, R_exp);
         double L = L_coeff * Lsun * pow(mass_ratio, L_exp);


### PR DESCRIPTION
## Summary
- allow each particle to specify its own SSE radius and luminosity scaling coefficients/exponents
- document SSE particle-level parameters
- note particle-level SSE parameters in core headers and defaults

## Testing
- `pytest` (fails: fixture 'reb_sim' not found for test_segfaults)
- `pytest -k "not test_segfaults"`


------
https://chatgpt.com/codex/tasks/task_e_68945c3a0e248332a0f2def93b507fee