### PR TITLE
Initialize default stellar luminosity

### DIFF
--- a/doc/effects.rst
+++ b/doc/effects.rst
@@ -568,7 +568,9 @@ Python Example          `stellar_evolution_sse.py <https://github.com/dtamayo/re
 Updates stellar radius and luminosity using simplified analytic
 mass--radius and mass--luminosity relations.  The operator stores the
 resulting values in ``swml_R`` and ``swml_L`` so other effects (e.g.,
-stellar winds) can access them.
+stellar winds) can access them.  When loaded, any particle lacking a
+``swml_L`` parameter is initialized to ``1`` (in units of ``sse_Lsun``)
+so that downstream operators have a sensible default luminosity.
 
 **Effect Parameters**
 

--- a/doc/latex/stellar_evolution_tracks.tex
+++ b/doc/latex/stellar_evolution_tracks.tex
@@ -13,7 +13,9 @@ its radius and luminosity using
 During the main sequence ($t<t_{\rm MS}$) the radius and luminosity
 increase linearly with $t/t_{\rm MS}$.  The updated values are stored
 on the particle itself and also as parameters ``swml_R`` and
-``swml_L`` so that other effects can access them.
+``swml_L`` so that other effects can access them.  When the operator
+is first loaded any particle missing ``swml_L`` is initialized to
+unity (in units of ``sse\_Lsun``).
 
 This implementation is highly approximate and intended only for simple
 experiments when a full stellar evolution code is unavailable.

--- a/src/core.c
+++ b/src/core.c
@@ -488,6 +488,15 @@ struct rebx_operator* rebx_load_operator(struct rebx_extras* const rebx, const c
     else if (strcmp(name, "stellar_evolution_sse") == 0){
         operator->step_function = rebx_stellar_evolution_sse;
         operator->operator_type = REBX_OPERATOR_UPDATER;
+        // Ensure a default luminosity parameter exists for all particles so
+        // other effects (e.g., stellar winds) can immediately access it.
+        struct reb_simulation* const sim = rebx->sim;
+        for (int i = 0; i < sim->N; i++){
+            struct reb_particle* const p = &sim->particles[i];
+            if (!rebx_get_param(rebx, p->ap, "swml_L")){
+                rebx_set_param_double(rebx, &p->ap, "swml_L", 1.0);
+            }
+        }
     }
     else if (strcmp(name, "roche_lobe_mass_transfer") == 0){
         operator->step_function = rebx_roche_lobe_mass_transfer;


### PR DESCRIPTION
## Summary
- Initialize `swml_L` to unity for all particles when loading `stellar_evolution_sse` so other operators can immediately access luminosity
- Document default `swml_L` behaviour in effect documentation

## Testing
- `pytest -q` *(fails: fixture 'reb_sim' not found)*

------
https://chatgpt.com/codex/tasks/task_e_689464a1fc98833284cb8a4c78d3355d