### PR TITLE
Use particle radius for thermally driven winds

### DIFF
--- a/src/thermally_driven_winds.c
+++ b/src/thermally_driven_winds.c
@@ -22,7 +22,7 @@
  * -------------------------
  *  tdw_eta        (double, req.) – heating efficiency η
  *  tdw_T          (double, req.) – coronal temperature  (same units as Tsun)
- *  tdw_R          (double, req.) – stellar radius       (same units as Rsun)
+ *  (stellar radius is taken from the particle's radius r)
  *
  * Notes
  * -----
@@ -86,12 +86,11 @@ void rebx_thermally_driven_winds(struct reb_simulation* const sim,
 
         const double* eta_ptr = rebx_get_param(rx, p->ap, "tdw_eta");
         const double* T_ptr   = rebx_get_param(rx, p->ap, "tdw_T");
-        const double* R_ptr   = rebx_get_param(rx, p->ap, "tdw_R");
-        if (!eta_ptr || !T_ptr || !R_ptr) continue;
+        if (!eta_ptr || !T_ptr) continue;
 
         const double eta = *eta_ptr;
         const double T   = *T_ptr;
-        const double R   = *R_ptr;
+        const double R   = p->r;
         if (eta <= 0.0 || !isfinite(eta)) continue;
         if (T   <= 0.0 || !isfinite(T  )) continue;
         if (R   <= 0.0 || !isfinite(R  )) continue;

--- a/tests_rebound-S/test_stellar_winds.py
+++ b/tests_rebound-S/test_stellar_winds.py
@@ -22,12 +22,10 @@ class TestStellarWinds(unittest.TestCase):
         star.params['swml_eta'] = 0.5
         star.params['tdw_eta'] = 1.0
         star.params['tdw_T'] = 1.5e6
-        star.params['tdw_R'] = star.r
 
         initial_mass = star.m
         for _ in range(5):
             sim.integrate(sim.t + 2.0e4)
-            star.params['tdw_R'] = star.r
 
         self.assertLess(star.m, initial_mass)
 


### PR DESCRIPTION
## Summary
- Use particle radius directly in thermally driven winds effect
- Update stellar winds test to rely on particle radius

## Testing
- `python setup.py build_ext --inplace`
- `pytest -q` *(fails: fixture 'reb_sim' not found in test_segfaults.py)*

------
https://chatgpt.com/codex/tasks/task_e_68947395426c833290c9e892975e2397