### PR TITLE
Use particle radius in wind modules

### DIFF
--- a/examples/stellar_wind_mass_loss/problem.c
+++ b/examples/stellar_wind_mass_loss/problem.c
@@ -20,6 +20,7 @@ int main(int argc, char* argv[]){
 
     struct reb_particle star = {0};
     star.m = 1.;
+    star.r = 1.0; // Rsun
     reb_simulation_add(sim, star);
     reb_simulation_move_to_com(sim);
 
@@ -29,7 +30,6 @@ int main(int argc, char* argv[]){
 
     // set stellar parameters
     rebx_set_param_double(rebx, &sim->particles[0].ap, "swml_eta", 0.5);
-    rebx_set_param_double(rebx, &sim->particles[0].ap, "swml_R", 1.0); // Rsun
     rebx_set_param_double(rebx, &sim->particles[0].ap, "swml_L", 1.0); // Lsun
 
     reb_simulation_integrate(sim, tmax);

--- a/src/core.c
+++ b/src/core.c
@@ -174,7 +174,6 @@ void rebx_register_default_params(struct rebx_extras* rebx){
     rebx_register_param(rebx, "ce_Qd", REBX_TYPE_DOUBLE);
     rebx_register_param(rebx, "swml_eta", REBX_TYPE_DOUBLE);
     rebx_register_param(rebx, "swml_L", REBX_TYPE_DOUBLE);
-    rebx_register_param(rebx, "swml_R", REBX_TYPE_DOUBLE);
     rebx_register_param(rebx, "swml_const", REBX_TYPE_DOUBLE);
     rebx_register_param(rebx, "swml_Msun", REBX_TYPE_DOUBLE);
     rebx_register_param(rebx, "swml_Rsun", REBX_TYPE_DOUBLE);
@@ -183,7 +182,6 @@ void rebx_register_default_params(struct rebx_extras* rebx){
     rebx_register_param(rebx, "swml_max_dlnM", REBX_TYPE_DOUBLE);
     rebx_register_param(rebx, "tdw_eta", REBX_TYPE_DOUBLE);
     rebx_register_param(rebx, "tdw_T", REBX_TYPE_DOUBLE);
-    rebx_register_param(rebx, "tdw_R", REBX_TYPE_DOUBLE);
     rebx_register_param(rebx, "tdw_const", REBX_TYPE_DOUBLE);
     rebx_register_param(rebx, "tdw_Msun", REBX_TYPE_DOUBLE);
     rebx_register_param(rebx, "tdw_Rsun", REBX_TYPE_DOUBLE);

--- a/src/stellar_evolution_sse.c
+++ b/src/stellar_evolution_sse.c
@@ -74,7 +74,6 @@ void rebx_stellar_evolution_sse(struct reb_simulation* const sim, struct rebx_op
         double R = R_coeff * Rsun * pow(mass_ratio, R_exp);
         double L = L_coeff * Lsun * pow(mass_ratio, L_exp);
         p->r = R;
-        rebx_set_param_double(rebx, &p->ap, "swml_R", R);
         rebx_set_param_double(rebx, &p->ap, "swml_L", L);
     }
 }

--- a/src/stellar_wind_mass_loss.c
+++ b/src/stellar_wind_mass_loss.c
@@ -20,7 +20,7 @@
  * -------------------------
  *  swml_eta    (double, required)  – dimensionless efficiency η
  *  swml_L      (double, required)  – stellar luminosity  (same units as Lsun)
- *  swml_R      (double, required)  – stellar radius      (same units as Rsun)
+ *  (stellar radius is taken from the particle's radius r)
  *
  * Notes
  * -----
@@ -77,13 +77,12 @@ void rebx_stellar_wind_mass_loss(struct reb_simulation* const sim,
         /* Fetch particle parameters */
         const double* eta_ptr = rebx_get_param(rx, p->ap, "swml_eta");
         const double* L_ptr   = rebx_get_param(rx, p->ap, "swml_L");
-        const double* R_ptr   = rebx_get_param(rx, p->ap, "swml_R");
 
-        if (!eta_ptr || !L_ptr || !R_ptr) continue;
+        if (!eta_ptr || !L_ptr) continue;
 
         const double eta = *eta_ptr;
         const double L   = *L_ptr;
-        const double R   = *R_ptr;
+        const double R   = p->r;
 
         /* Sanity checks */
         if (!isfinite(eta) || eta <= 0.0) continue;


### PR DESCRIPTION
## Summary
- Use each particle's `r` field directly for stellar wind mass loss
- Drop `swml_R` and `tdw_R` parameter registrations
- Keep stellar radius only in the particle when using simplified SSE
- Update stellar wind example to set radius on the particle

## Testing
- `python all_tests.py` *(fails: Parameter 'gw_decay_on' not found in REBOUNDx)*
- `python all_tests2.py` *(fails: Parameter 'rlmt_last_dE' not registered)*


------
https://chatgpt.com/codex/tasks/task_e_68999bb058588332a46dccbba0f84431