### PR TITLE
Rename swml to sse in simplified stellar evolution operator

### DIFF
--- a/doc_binary.tex
+++ b/doc_binary.tex
@@ -394,9 +394,8 @@ and luminosity in code units.  Each particle may override the scaling using the
 particle-level parameters \texttt{sse\_R\_coeff}, \texttt{sse\_R\_exp},
 \texttt{sse\_L\_coeff}, and \texttt{sse\_L\_exp}; if unspecified, the default
 values in Table~\ref{tab:sse} are applied.  The particle's radius field is
-replaced by $R$, and the values $R$ and $L$ are written to the attributes
-\texttt{swml\_R} and \texttt{swml\_L} so that the wind-mass-loss operator can
-consume them. Virtual particles are skipped, and stellar masses remain
+replaced by $R$, and the luminosity $L$ is written to the attribute
+\texttt{sse\_L}. Virtual particles are skipped, and stellar masses remain
 unchanged.
 
 \begin{table}[h]

--- a/examples/stellar_evolution_sse/problem.c
+++ b/examples/stellar_evolution_sse/problem.c
@@ -33,7 +33,7 @@ int main(int argc, char* argv[]){
         reb_simulation_integrate(sim, (i+1)*tmax/10.);
         printf("t=%e R=%f L=%f\n", sim->t,
                sim->particles[0].r,
-               *rebx_get_param(rebx, sim->particles[0].ap, "swml_L"));
+               *rebx_get_param(rebx, sim->particles[0].ap, "sse_L"));
     }
 
     rebx_free(rebx);

--- a/ipython_examples/stellar_evolution_sse.py
+++ b/ipython_examples/stellar_evolution_sse.py
@@ -14,7 +14,7 @@ print("Default main-sequence scaling:")
 for i in range(5):
     sim.integrate(sim.t+1e3)
     R = sim.particles[0].r
-    L = sim.particles[0].params['swml_L']
+    L = sim.particles[0].params['sse_L']
     print(f"t={sim.t:.0f} yr, R={R:.4f} Rsun, L={L:.4f} Lsun")
 
 # Customize parameters
@@ -31,7 +31,7 @@ print("Default main-sequence evolution:")
 for i in range(5):
     sim.integrate(sim.t+1e3)
     R = sim.particles[0].r
-    L = sim.particles[0].params['swml_L']
+    L = sim.particles[0].params['sse_L']
     print(f"t={sim.t:.0f} yr, R={R:.4f} Rsun, L={L:.4f} Lsun")
 
 # Customize parameters
@@ -49,5 +49,5 @@ print("\nCustom parameters:")
 for i in range(5):
     sim.integrate(sim.t+1e3)
     R = sim.particles[0].r
-    L = sim.particles[0].params['swml_L']
+    L = sim.particles[0].params['sse_L']
     print(f"t={sim.t:.0f} yr, R={R:.4f} Rsun, L={L:.4f} Lsun")

--- a/ipython_examples/stellar_wind_with_sse.py
+++ b/ipython_examples/stellar_wind_with_sse.py
@@ -23,5 +23,5 @@ for i in range(5):
     sim.integrate(sim.t + 2e10)
     M = sim.particles[0].m
     R = sim.particles[0].r
-    L = sim.particles[0].params['swml_L']
+    L = sim.particles[0].params['sse_L']
     print(f"t={sim.t:.0f} yr, M={M:.6f} Msun, R={R:.3f} Rsun, L={L:.3f} Lsun")

--- a/src/core.c
+++ b/src/core.c
@@ -201,6 +201,7 @@ void rebx_register_default_params(struct rebx_extras* rebx){
     rebx_register_param(rebx, "sse_R_exp", REBX_TYPE_DOUBLE);
     rebx_register_param(rebx, "sse_L_coeff", REBX_TYPE_DOUBLE);
     rebx_register_param(rebx, "sse_L_exp", REBX_TYPE_DOUBLE);
+    rebx_register_param(rebx, "sse_L", REBX_TYPE_DOUBLE);
     rebx_register_param(rebx, "mb_on", REBX_TYPE_INT);
     rebx_register_param(rebx, "mb_convective", REBX_TYPE_INT);
     rebx_register_param(rebx, "mb_omega_sat", REBX_TYPE_DOUBLE);
@@ -487,12 +488,12 @@ struct rebx_operator* rebx_load_operator(struct rebx_extras* const rebx, const c
         operator->step_function = rebx_stellar_evolution_sse;
         operator->operator_type = REBX_OPERATOR_UPDATER;
         // Ensure a default luminosity parameter exists for all particles so
-        // other effects (e.g., stellar winds) can immediately access it.
+        // other effects can immediately access it.
         struct reb_simulation* const sim = rebx->sim;
         for (int i = 0; i < sim->N; i++){
             struct reb_particle* const p = &sim->particles[i];
-            if (!rebx_get_param(rebx, p->ap, "swml_L")){
-                rebx_set_param_double(rebx, &p->ap, "swml_L", 1.0);
+            if (!rebx_get_param(rebx, p->ap, "sse_L")){
+                rebx_set_param_double(rebx, &p->ap, "sse_L", 1.0);
             }
         }
     }

--- a/src/stellar_evolution_sse.c
+++ b/src/stellar_evolution_sse.c
@@ -74,6 +74,6 @@ void rebx_stellar_evolution_sse(struct reb_simulation* const sim, struct rebx_op
         double R = R_coeff * Rsun * pow(mass_ratio, R_exp);
         double L = L_coeff * Lsun * pow(mass_ratio, L_exp);
         p->r = R;
-        rebx_set_param_double(rebx, &p->ap, "swml_L", L);
+        rebx_set_param_double(rebx, &p->ap, "sse_L", L);
     }
 }


### PR DESCRIPTION
## Summary
- rename `swml_L` to `sse_L` in simplified stellar evolution operator
- register and initialize new `sse_L` parameter
- update docs and examples to use `sse_L`

## Testing
- `pytest` *(fails: fixture 'reb_sim' not found in test_segfaults.py)*

------
https://chatgpt.com/codex/tasks/task_e_68999f539d9483328c3601a0828277df