### PR TITLE
Use SSE luminosity for thermally driven wind mass loss

### DIFF
--- a/src/core.c
+++ b/src/core.c
@@ -181,14 +181,13 @@ void rebx_register_default_params(struct rebx_extras* rebx){
     rebx_register_param(rebx, "swml_year", REBX_TYPE_DOUBLE);
     rebx_register_param(rebx, "swml_max_dlnM", REBX_TYPE_DOUBLE);
     rebx_register_param(rebx, "tdw_eta", REBX_TYPE_DOUBLE);
-    rebx_register_param(rebx, "tdw_T", REBX_TYPE_DOUBLE);
     rebx_register_param(rebx, "tdw_const", REBX_TYPE_DOUBLE);
     rebx_register_param(rebx, "tdw_Msun", REBX_TYPE_DOUBLE);
     rebx_register_param(rebx, "tdw_Rsun", REBX_TYPE_DOUBLE);
-    rebx_register_param(rebx, "tdw_Tsun", REBX_TYPE_DOUBLE);
+    rebx_register_param(rebx, "tdw_Lsun", REBX_TYPE_DOUBLE);
     rebx_register_param(rebx, "tdw_year", REBX_TYPE_DOUBLE);
     rebx_register_param(rebx, "tdw_alpha_R", REBX_TYPE_DOUBLE);
-    rebx_register_param(rebx, "tdw_alpha_T", REBX_TYPE_DOUBLE);
+    rebx_register_param(rebx, "tdw_alpha_L", REBX_TYPE_DOUBLE);
     rebx_register_param(rebx, "tdw_alpha_M", REBX_TYPE_DOUBLE);
     rebx_register_param(rebx, "tdw_max_dlnM", REBX_TYPE_DOUBLE);
     // Simplified stellar evolution operator

--- a/tests_rebound-S/test_stellar_winds.py
+++ b/tests_rebound-S/test_stellar_winds.py
@@ -11,17 +11,16 @@ class TestStellarWinds(unittest.TestCase):
         sim.add(m=1.0, r=1.0)
 
         rebx = reboundx.Extras(sim)
+        sse = rebx.load_operator('stellar_evolution_sse')
+        rebx.add_operator(sse)
         swml = rebx.load_operator('stellar_wind_mass_loss')
         rebx.add_operator(swml)
         tdw = rebx.load_operator('thermally_driven_winds')
         rebx.add_operator(tdw)
-        sse = rebx.load_operator('stellar_evolution_sse')
-        rebx.add_operator(sse)
 
         star = sim.particles[0]
         star.params['swml_eta'] = 0.5
         star.params['tdw_eta'] = 1.0
-        star.params['tdw_T'] = 1.5e6
 
         initial_mass = star.m
         for _ in range(5):


### PR DESCRIPTION
## Summary
- Replace temperature-based scaling in thermally driven winds with luminosity `sse_L`
- Read stellar mass and radius directly from particle properties
- Register new tdw_Lsun/alpha_L parameters and adjust tests

## Testing
- `pytest tests_rebound-S/test_stellar_winds.py -q`


------
https://chatgpt.com/codex/tasks/task_e_6899a3d9765c8332a66cd5ad34ee112f