### PR TITLE
Use sse_L luminosity for stellar wind mass loss

### DIFF
--- a/src/core.c
+++ b/src/core.c
@@ -172,7 +172,6 @@ void rebx_register_default_params(struct rebx_extras* rebx){
     rebx_register_param(rebx, "ce_xmin", REBX_TYPE_DOUBLE);
     rebx_register_param(rebx, "ce_Qd", REBX_TYPE_DOUBLE);
     rebx_register_param(rebx, "swml_eta", REBX_TYPE_DOUBLE);
-    rebx_register_param(rebx, "swml_L", REBX_TYPE_DOUBLE);
     rebx_register_param(rebx, "swml_const", REBX_TYPE_DOUBLE);
     rebx_register_param(rebx, "swml_Msun", REBX_TYPE_DOUBLE);
     rebx_register_param(rebx, "swml_Rsun", REBX_TYPE_DOUBLE);

--- a/src/stellar_wind_mass_loss.c
+++ b/src/stellar_wind_mass_loss.c
@@ -19,8 +19,9 @@
  * Particle‑level parameters
  * -------------------------
  *  swml_eta    (double, required)  – dimensionless efficiency η
- *  swml_L      (double, required)  – stellar luminosity  (same units as Lsun)
- *  (stellar radius is taken from the particle's radius r)
+ *  (stellar radius is taken from the particle's radius r; stellar
+ *  luminosity is read from the ``sse_L`` parameter set by the
+ *  \ref stellar_evolution_sse.c "stellar evolution" operator.)
  *
  * Notes
  * -----
@@ -76,7 +77,7 @@ void rebx_stellar_wind_mass_loss(struct reb_simulation* const sim,
 
         /* Fetch particle parameters */
         const double* eta_ptr = rebx_get_param(rx, p->ap, "swml_eta");
-        const double* L_ptr   = rebx_get_param(rx, p->ap, "swml_L");
+        const double* L_ptr   = rebx_get_param(rx, p->ap, "sse_L");
 
         if (!eta_ptr || !L_ptr) continue;
 


### PR DESCRIPTION
## Summary
- Remove `swml_L` particle parameter and read luminosity from `sse_L` set by the simplified stellar evolution operator
- Drop registration of unused `swml_L` parameter

## Testing
- `make` *(fails: REBOUNDx not in same directory as REBOUND; missing dependency)*
- `pytest` *(fails: cannot load `libreboundx` shared library)*

------
https://chatgpt.com/codex/tasks/task_e_689d8e539acc833284f62956bf5515fd