### PR TITLE
Use sse_L for Eddington winds

### DIFF
--- a/doc_binary.tex
+++ b/doc_binary.tex
@@ -24,12 +24,13 @@
 
 \title{\textsc{Binary‑Star Evolution Modules in
          \textnormal{REBOUNDx}}:\\
-       Roche‑Lobe Transfer, Magnetic Braking, Stellar Winds, Thermally Driven Winds, Simplified
-       Stellar Evolution, and Relativity}
+       Roche‑Lobe Transfer, Magnetic Braking, Stellar Winds, Thermally Driven Winds, Eddington Winds,
+       Simplified Stellar Evolution, and Relativity}
 \author{Operator files: \texttt{roche\_lobe\_mass\_transfer.c},
         \texttt{magnetic\_braking.c},
         \texttt{stellar\_wind\_mass\_loss.c},
         \texttt{thermally\_driven\_winds.c},
+        \texttt{eddington\_winds.c},
         \texttt{stellar\_evolution\_sse.c},
         \texttt{post\_newtonian.c}\\
         Revision B – 10 July 2025}
@@ -378,6 +379,45 @@ Name (scope) & Unit & Default & Purpose \\
 \texttt{tdw\_alpha\_L} (op) & — & $3/2$ & Exponent $\alpha_L$ on $L/L_\odot$\\
 \texttt{tdw\_alpha\_M} (op) & — & 1 & Exponent $\alpha_M$ on $M_\odot/M$\\
 \texttt{tdw\_max\_dlnM} (op) & — & 0.1 & Max $|\Delta M|/M$ per call\\
+\bottomrule
+\end{tabular}
+\end{table}
+
+\subsection{Eddington Winds}
+\label{sec:edw}
+
+Luminosities that exceed the electron-scattering Eddington limit can drive
+isotropic mass loss. For a star of mass $M$ and luminosity $L$, the rate is
+\[
+\dot M = -C_{\rm edd}\,\max\!\left(0, \frac{L}{L_{\rm Edd}} - 1\right)
+\;M_\odot\,\mathrm{yr}^{-1},
+\]
+where $L_{\rm Edd} = L_{\rm Edd,0}(M/M_\odot)L_\odot$ with the coefficient
+$L_{\rm Edd,0}$ set by the operator parameter \texttt{edw\_Ledd\_coeff}. The
+luminosity $L$ must be provided via the particle attribute \texttt{sse\_L},
+for example by the simplified stellar-evolution operator. Mass is removed
+isotropically with no linear-momentum recoil; virtual particles are ignored
+and the system is recentred on the centre of mass. The normalisation,
+unit conversions, Eddington coefficient, year length, and safety cap on
+the fractional mass change are adjustable via operator parameters
+summarised in Table~\ref{tab:edw}. The operator is unit-agnostic if the
+scaling constants are supplied consistently.
+
+\begin{table}[h]
+\centering\footnotesize
+\caption{Eddington wind parameters}
+\label{tab:edw}
+\begin{tabular}{@{}llll@{}}
+\toprule
+Name (scope) & Unit & Default & Purpose \\
+\midrule
+\texttt{sse\_L} (part) & luminosity & — & Stellar luminosity $L$\\[0.2em]
+\texttt{edw\_const} (op) & $M_\odot$/yr & $10^{-6}$ & Mass-loss prefactor $C_{\rm edd}$\\
+\texttt{edw\_Msun} (op) & mass & 1 & Solar mass in code units\\
+\texttt{edw\_Lsun} (op) & luminosity & 1 & Solar luminosity in code units\\
+\texttt{edw\_year} (op) & time & 1 & Length of Julian year in code units\\
+\texttt{edw\_Ledd\_coeff} (op) & $L_\odot/M_\odot$ & $3.2\times10^{4}$ & Eddington coefficient\\
+\texttt{edw\_max\_dlnM} (op) & — & 0.1 & Max $|\Delta M|/M$ per call\\
 \bottomrule
 \end{tabular}
 \end{table}

--- a/reboundx/test/test_segfaults.py
+++ b/reboundx/test/test_segfaults.py
@@ -24,13 +24,13 @@ def droprebx():
     sim, rebx = makegr()
     return sim
 
-def testEffect(reb_sim):
+def effect(reb_sim):
     reb_sim.contents.particles[0].params['c'] = 1.
     
 class TestSegFaults(unittest.TestCase):
     def test_detach_preserves_force(self):
         sim, rebx = make()
-        sim.additional_forces = testEffect
+        sim.additional_forces = effect
         addmass = rebx.load_operator('modify_mass')
         rebx.add_operator(addmass, dtfraction=1.,  timing="pre")
         rebx.detach(sim)
@@ -39,7 +39,7 @@ class TestSegFaults(unittest.TestCase):
     
     def test_detach_preserves_pretm(self):
         sim, rebx = make()
-        sim.pre_timestep_modifications = testEffect
+        sim.pre_timestep_modifications = effect
         addmass = rebx.load_operator('modify_mass')
         rebx.add_operator(addmass, dtfraction=1.,  timing="post")
         rebx.detach(sim)
@@ -48,7 +48,7 @@ class TestSegFaults(unittest.TestCase):
     
     def test_detach_preserves_pretm(self):
         sim, rebx = make()
-        sim.post_timestep_modifications = testEffect
+        sim.post_timestep_modifications = effect
         gr = rebx.load_force('gr')
         rebx.add_force(gr)
         rebx.detach(sim)

--- a/src/eddington_winds.c
+++ b/src/eddington_winds.c
@@ -23,7 +23,7 @@
  *
  * Particle-level parameters
  * -------------------------
- *  edw_L or sse_L   (double, req.) – stellar luminosity (units of L☉)
+ *  sse_L           (double, req.) – stellar luminosity (units of L☉)
  *
  * Notes
  * -----
@@ -75,9 +75,8 @@ void rebx_eddington_winds(struct reb_simulation* const sim,
         struct reb_particle* const p = &sim->particles[i];
         if (p->m <= 0.0 || !isfinite(p->m)) continue;
 
-        /* Accept L from either edw_L or sse_L (SSE pipeline friendly) */
-        const double* Lp = rebx_get_param(rx, p->ap, "edw_L");
-        if (!Lp)         Lp = rebx_get_param(rx, p->ap, "sse_L");
+        /* Stellar luminosity supplied via sse_L (e.g. from SSE operator) */
+        const double* Lp = rebx_get_param(rx, p->ap, "sse_L");
         if (!Lp) continue;
 
         const double L = *Lp;

--- a/tests_rebound-S/test_eddington_winds.py
+++ b/tests_rebound-S/test_eddington_winds.py
@@ -12,7 +12,7 @@ def test_eddington_mass_loss():
     rebx.add_operator(op)
 
     star = sim.particles[0]
-    star.params['eddw_L'] = 1e5
+    star.params['sse_L'] = 1e5
     m0 = star.m
     sim.integrate(1e3)
     assert star.m < m0


### PR DESCRIPTION
## Summary
- drop `edw_L` particle parameter and always read luminosity from `sse_L`
- document Eddington-wind inputs in `doc_binary.tex`
- adjust tests for new parameter and avoid unintended test collection

## Testing
- `python setup.py build_ext --inplace`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689d92a620148332ad15a0a2ccabf927