### PR TITLE
Harmonize wind modules with Roche lobe overflow

### DIFF
--- a/src/eddington_winds.c
+++ b/src/eddington_winds.c
@@ -68,6 +68,11 @@ void rebx_eddington_winds(struct reb_simulation* const sim,
 
     #undef GET
 
+    const double* pDisCE   = rebx_get_param(rx, op->ap, "edw_disable_in_CE");
+    const double* pDisRLOF = rebx_get_param(rx, op->ap, "edw_disable_in_RLOF");
+    const int disable_in_CE   = pDisCE   ? (int)llround(*pDisCE)   : 1;
+    const int disable_in_RLOF = pDisRLOF ? (int)llround(*pDisRLOF) : 1;
+
     const double pref = (C0 * Msun) / year_len; /* code mass per code time */
 
     /* ----------------- iterate over real particles ----------------- */
@@ -78,6 +83,13 @@ void rebx_eddington_winds(struct reb_simulation* const sim,
         /* Stellar luminosity supplied via sse_L (e.g. from SSE operator) */
         const double* Lp = rebx_get_param(rx, p->ap, "sse_L");
         if (!Lp) continue;
+
+        const double* inCE = rebx_get_param(rx, p->ap, "inside_CE");
+        const double* rlof = rebx_get_param(rx, p->ap, "rlof_active");
+        if ( (disable_in_CE   && inCE  && *inCE  > 0.5) ||
+             (disable_in_RLOF && rlof && *rlof > 0.5) ){
+            continue;
+        }
 
         const double L = *Lp;
         if (!isfinite(L) || L <= 0.0) continue;

--- a/src/thermally_driven_winds.c
+++ b/src/thermally_driven_winds.c
@@ -77,6 +77,11 @@ void rebx_thermally_driven_winds(struct reb_simulation* const sim,
     GET("tdw_max_dlnM", max_dlnM );
     #undef GET
 
+    const double* pDisCE   = rebx_get_param(rx, op->ap, "tdw_disable_in_CE");
+    const double* pDisRLOF = rebx_get_param(rx, op->ap, "tdw_disable_in_RLOF");
+    const int disable_in_CE   = pDisCE   ? (int)llround(*pDisCE)   : 1;
+    const int disable_in_RLOF = pDisRLOF ? (int)llround(*pDisRLOF) : 1;
+
     /* Convert the prefactor to code‑mass per code‑time */
     const double pref = (C0 * Msun) / year_len;
 
@@ -87,6 +92,13 @@ void rebx_thermally_driven_winds(struct reb_simulation* const sim,
         const double* eta_ptr = rebx_get_param(rx, p->ap, "tdw_eta");
         const double* L_ptr   = rebx_get_param(rx, p->ap, "sse_L");
         if (!eta_ptr || !L_ptr) continue;
+
+        const double* inCE = rebx_get_param(rx, p->ap, "inside_CE");
+        const double* rlof = rebx_get_param(rx, p->ap, "rlof_active");
+        if ( (disable_in_CE   && inCE  && *inCE  > 0.5) ||
+             (disable_in_RLOF && rlof && *rlof > 0.5) ){
+            continue;
+        }
 
         const double eta = *eta_ptr;
         const double L   = *L_ptr;


### PR DESCRIPTION
## Summary
- Flag RLOF and common-envelope phases on participating particles so other wind modules can react
- Add opt-out parameters and disable stand-alone winds during RLOF/CE by default
- Correct momentum and angular-momentum handling for RLOF wind mass loss

## Testing
- `pip install -e .`
- `pytest tests_rebound-S/test_stellar_winds.py tests_rebound-S/test_eddington_winds.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689edcf055548332b5bd8610aa4c7b20