### PR TITLE
docs: clarify SSE and RLOF wind recoil

### DIFF
--- a/doc_binary.tex
+++ b/doc_binary.tex
@@ -510,9 +510,8 @@ parameter:
 &&\text{implicit AM loss via donor mass decrement},\\
 \text{mode 1:}~& \mathbf v_{\rm loss}=\mathbf v_{\rm a}, 
 &&\text{implicit AM loss via donor mass decrement},\\
-\text{mode 2:}~& \mathbf v_{\rm loss}=\mathbf v_{\rm CM}, 
-&&\text{no explicit wind torque, but the donor’s mass decrement still removes 
-angular momentum } m_{\rm wind}(\mathbf r_{\rm d}-\mathbf R_{\rm CM})\times\mathbf v_{\rm d},\\
+\text{mode 2:}~& \mathbf v_{\rm loss}=\mathbf v_{\rm CM},
+&&\text{wind removes centre-of-mass momentum } m_{\rm wind}\mathbf v_{\rm CM};\,\text{the donor’s mass decrement still subtracts } m_{\rm wind}(\mathbf r_{\rm d}-\mathbf R_{\rm CM})\times\mathbf v_{\rm d},\\
 \text{mode 3 (target-$j$):}~& |\mathbf v_{\rm loss}-\mathbf v_{\rm emit}| 
 = f_j\,j_{\rm orb}/r \quad\text{along }\hat e_\perp\!\perp\hat{\mathbf r},\\
 & j_{\rm orb}\equiv J/M=\mu\,|\mathbf r\times\mathbf v|/(M_{\rm d}+M_{\rm a}),\quad


### PR DESCRIPTION
## Summary
- document that `stellar_evolution_sse` recomputes radii/luminosities algebraically each call
- clarify `roche_lobe_mass_transfer` j-loss mode 2 removes center-of-mass momentum

## Testing
- `pytest` *(fails: OSError: /workspace/reboundx/libreboundx.cpython-312-x86_64-linux-gnu.so: cannot open shared object file)*

------
https://chatgpt.com/codex/tasks/task_e_68b165fcc45083329ff32384189d6856